### PR TITLE
React native deprecation fix

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -62,6 +62,7 @@
   "jsnext:main": "es/index.js",
   "types": "./index.d.ts",
   "dependencies": {
+    "@react-native-community/async-storage": "^1.8.1",
     "buffer": "4.9.1",
     "crypto-js": "3.1.9-1",
     "js-cookie": "^2.1.4"

--- a/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
+++ b/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};


### PR DESCRIPTION
… own package very soon. Amazon does not update this library anymore so we have to fix it ourselves or be stuck on an older react-native version forever.
